### PR TITLE
Fix student hostel module button breakages

### DIFF
--- a/src/StudentModules/Hostel/DownloadReceiptsPage.tsx
+++ b/src/StudentModules/Hostel/DownloadReceiptsPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { 
   Download, FileText, Calendar, Clock, DollarSign, 
   Eye, Search, Filter, CheckCircle, AlertCircle,
-  Home, Building2, User, Phone, Mail, RefreshCw
+  Home, Building2, User, Phone, Mail, RefreshCw, X
 } from 'lucide-react';
 
 interface Receipt {

--- a/src/StudentModules/Hostel/GiveFeedbackPage.tsx
+++ b/src/StudentModules/Hostel/GiveFeedbackPage.tsx
@@ -3,7 +3,7 @@ import {
   Star, MessageSquare, ThumbsUp, ThumbsDown, 
   Clock, CheckCircle, AlertTriangle, User, 
   Calendar, FileText, RefreshCw, Filter, Search,
-  Send, Heart, Smile, Frown, Meh
+  Send, Heart, Smile, Frown, Meh, X
 } from 'lucide-react';
 
 interface FeedbackForm {

--- a/src/StudentModules/Hostel/PreRegisterVisitorPage.tsx
+++ b/src/StudentModules/Hostel/PreRegisterVisitorPage.tsx
@@ -3,7 +3,7 @@ import {
   UserPlus, Calendar, Clock, MapPin, Phone, 
   User, FileText, Camera, QrCode, CheckCircle,
   AlertTriangle, Send, RefreshCw, Filter, Search,
-  CalendarDays, Users, Eye, Edit, Trash2
+  CalendarDays, Users, Eye, Edit, Trash2, X
 } from 'lucide-react';
 
 interface VisitorRegistration {

--- a/src/StudentModules/Hostel/TrackComplaintStatusPage.tsx
+++ b/src/StudentModules/Hostel/TrackComplaintStatusPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { 
   Eye, Clock, CheckCircle, AlertTriangle, User, 
   Calendar, MessageSquare, FileText, MapPin, Camera,
-  Star, ThumbsUp, ThumbsDown, RefreshCw, Filter, Search
+  Star, ThumbsUp, ThumbsDown, RefreshCw, Filter, Search, X
 } from 'lucide-react';
 
 interface ComplaintStatus {

--- a/src/StudentModules/Hostel/TrackLeaveReturnPage.tsx
+++ b/src/StudentModules/Hostel/TrackLeaveReturnPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { 
   Clock, MapPin, Calendar, CheckCircle, AlertCircle, 
   User, Phone, Home, Building2, Eye, RefreshCw,
-  FileText, QrCode, Download, Bell, Activity
+  FileText, QrCode, Download, Bell, Activity, X
 } from 'lucide-react';
 
 interface LeaveTracking {
@@ -206,7 +206,6 @@ const TrackLeaveReturnPage: React.FC = () => {
       case 'Completed': return 'bg-blue-100 text-blue-800';
       case 'Overdue': return 'bg-red-100 text-red-800';
       case 'Cancelled': return 'bg-gray-100 text-gray-800';
-      case 'Completed': return 'bg-green-100 text-green-800';
       case 'Pending': return 'bg-yellow-100 text-yellow-800';
       case 'Missed': return 'bg-red-100 text-red-800';
       default: return 'bg-gray-100 text-gray-800';

--- a/src/StudentModules/Hostel/VisitorLogsPage.tsx
+++ b/src/StudentModules/Hostel/VisitorLogsPage.tsx
@@ -3,7 +3,7 @@ import {
   ClipboardList, Calendar, Clock, MapPin, Phone, 
   User, FileText, QrCode, CheckCircle, AlertTriangle,
   Eye, Filter, Search, Download, RefreshCw, CalendarDays,
-  Users, TrendingUp, BarChart3, Clock3, CheckSquare
+  Users, TrendingUp, BarChart3, Clock3, CheckSquare, X
 } from 'lucide-react';
 
 interface VisitorLog {


### PR DESCRIPTION
Fix broken buttons in the student hostel module by adding missing `X` icon imports and resolving a duplicate case clause.

The missing `X` icon imports caused JavaScript errors when users clicked modal close buttons, rendering modals and their interactive elements (like "Register Visitor") non-functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4d4b70d-e9d0-4b54-8d6d-976e494dfe8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4d4b70d-e9d0-4b54-8d6d-976e494dfe8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

